### PR TITLE
Added a way to disable incorrect barcodes and restore default scanner settings

### DIFF
--- a/Over21.xcodeproj/project.pbxproj
+++ b/Over21.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		5273A25A21700E8600F4634B /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5273A25921700E8600F4634B /* ResultView.swift */; };
 		5274045E21922508007AF90E /* AgeLimitSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5274045D21922508007AF90E /* AgeLimitSelectionView.swift */; };
 		5274046021926078007AF90E /* NotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5274045F21926078007AF90E /* NotificationsView.swift */; };
+		5274046C219B4C7B007AF90E /* ContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5274046B219B4C7B007AF90E /* ContainerViewController.swift */; };
+		5274046E219B4EC2007AF90E /* SettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5274046D219B4EC2007AF90E /* SettingsController.swift */; };
+		52740471219B5FC3007AF90E /* SettingsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52740470219B5FC3007AF90E /* SettingsCell.swift */; };
+		52740473219B69DA007AF90E /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52740472219B69DA007AF90E /* Settings.swift */; };
 		D3F9ADBA08A10B106A1D2311 /* Pods_Over21.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBDA9A27CA50B44352D316F3 /* Pods_Over21.framework */; };
 /* End PBXBuildFile section */
 
@@ -33,6 +37,10 @@
 		5273A25921700E8600F4634B /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
 		5274045D21922508007AF90E /* AgeLimitSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgeLimitSelectionView.swift; sourceTree = "<group>"; };
 		5274045F21926078007AF90E /* NotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsView.swift; sourceTree = "<group>"; };
+		5274046B219B4C7B007AF90E /* ContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerViewController.swift; sourceTree = "<group>"; };
+		5274046D219B4EC2007AF90E /* SettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsController.swift; sourceTree = "<group>"; };
+		52740470219B5FC3007AF90E /* SettingsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCell.swift; sourceTree = "<group>"; };
+		52740472219B69DA007AF90E /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		D271FC4D14509537ADB710D2 /* Pods-Over21.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Over21.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Over21/Pods-Over21.debug.xcconfig"; sourceTree = "<group>"; };
 		DE74B030E9D5F1E6F34F58DC /* Pods-Over21.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Over21.release.xcconfig"; path = "Pods/Target Support Files/Pods-Over21/Pods-Over21.release.xcconfig"; sourceTree = "<group>"; };
 		EBDA9A27CA50B44352D316F3 /* Pods_Over21.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Over21.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -81,12 +89,13 @@
 			children = (
 				5273A25621700B8D00F4634B /* models */,
 				52628211215ECD4500E291D4 /* views */,
+				5274046A219B4C4E007AF90E /* controllers */,
 				526281FF215EC71C00E291D4 /* AppDelegate.swift */,
-				52628201215EC71C00E291D4 /* ViewController.swift */,
 				52628203215EC71C00E291D4 /* Main.storyboard */,
 				52628206215EC71C00E291D4 /* Assets.xcassets */,
 				52628208215EC71C00E291D4 /* LaunchScreen.storyboard */,
 				5262820B215EC71C00E291D4 /* Info.plist */,
+				52740472219B69DA007AF90E /* Settings.swift */,
 			);
 			path = Over21;
 			sourceTree = "<group>";
@@ -98,6 +107,7 @@
 				5273A25921700E8600F4634B /* ResultView.swift */,
 				5274045D21922508007AF90E /* AgeLimitSelectionView.swift */,
 				5274045F21926078007AF90E /* NotificationsView.swift */,
+				52740470219B5FC3007AF90E /* SettingsCell.swift */,
 			);
 			path = views;
 			sourceTree = "<group>";
@@ -108,6 +118,16 @@
 				5273A25721700B9700F4634B /* Age.swift */,
 			);
 			path = models;
+			sourceTree = "<group>";
+		};
+		5274046A219B4C4E007AF90E /* controllers */ = {
+			isa = PBXGroup;
+			children = (
+				5274046B219B4C7B007AF90E /* ContainerViewController.swift */,
+				52628201215EC71C00E291D4 /* ViewController.swift */,
+				5274046D219B4EC2007AF90E /* SettingsController.swift */,
+			);
+			path = controllers;
 			sourceTree = "<group>";
 		};
 		79F5A90334BE1DDD30B31FAC /* Pods */ = {
@@ -272,12 +292,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5274046E219B4EC2007AF90E /* SettingsController.swift in Sources */,
+				5274046C219B4C7B007AF90E /* ContainerViewController.swift in Sources */,
 				52628202215EC71C00E291D4 /* ViewController.swift in Sources */,
 				5273A25821700B9700F4634B /* Age.swift in Sources */,
+				52740471219B5FC3007AF90E /* SettingsCell.swift in Sources */,
 				5273A25A21700E8600F4634B /* ResultView.swift in Sources */,
 				52628213215ECD5400E291D4 /* AgeIndicatorView.swift in Sources */,
 				52628200215EC71C00E291D4 /* AppDelegate.swift in Sources */,
 				5274045E21922508007AF90E /* AgeLimitSelectionView.swift in Sources */,
+				52740473219B69DA007AF90E /* Settings.swift in Sources */,
 				5274046021926078007AF90E /* NotificationsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Over21/AppDelegate.swift
+++ b/Over21/AppDelegate.swift
@@ -19,11 +19,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         initializeFabricAndCrashlytics()
+        setupControllers()
         return true
     }
     
     private func initializeFabricAndCrashlytics() {
         Fabric.with([Crashlytics.self])
+    }
+    
+    private func setupControllers() {
+        let containerController = ContainerViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
+        window = UIWindow(frame: UIScreen.main.bounds)
+        window?.rootViewController = containerController
+        window?.makeKeyAndVisible()
     }
 
     func applicationWillResignActive(_ application: UIApplication) {

--- a/Over21/Base.lproj/Main.storyboard
+++ b/Over21/Base.lproj/Main.storyboard
@@ -1,24 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
     </dependencies>
-    <scenes>
-        <!--View Controller-->
-        <scene sceneID="tne-QT-ifu">
-            <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
-            </objects>
-        </scene>
-    </scenes>
+    <scenes/>
 </document>

--- a/Over21/Settings.swift
+++ b/Over21/Settings.swift
@@ -60,7 +60,6 @@ class Settings: NSObject {
     public func restoreDefaultSettings() {
         
         guard let device = CaptureHelper.sharedInstance.getDevices().first else { return }
-        print("device friendly name: \(device.deviceInfo.name)")
         
         if let listOfDisabledSymbologies = disabledSymbologies {
             

--- a/Over21/Settings.swift
+++ b/Over21/Settings.swift
@@ -1,0 +1,90 @@
+//
+//  Settings.swift
+//  Over21
+//
+//  Created by Chrishon Wyllie on 11/13/18.
+//  Copyright © 2018 Socket Mobile. All rights reserved.
+//
+
+import UIKit
+import SKTCapture
+
+class Settings: NSObject {
+    
+    private let symbologiesKey: String = "disabledSymbologies"
+    
+    public static var shared = Settings()
+    
+    private override init() {
+        super.init()
+    }
+    
+    private var device = CaptureHelper.sharedInstance.getDevices().first
+    
+    
+    public var disabledSymbologies: [Int]? {
+        return UserDefaults.standard.array(forKey: symbologiesKey) as? [Int]
+    }
+    
+    public func disableDataSource(withId symbologyId: SKTCaptureDataSourceID, forDevice device: CaptureHelperDevice) {
+        
+        var listOfDisabledSymbologies: [Int] = []
+        
+        if let list = disabledSymbologies {
+            listOfDisabledSymbologies = list
+        }
+        
+        guard listOfDisabledSymbologies.contains(symbologyId.rawValue) == false else {
+            // Keep from adding the same disabled symbologies more than once
+            return
+        }
+        
+        listOfDisabledSymbologies.append(symbologyId.rawValue)
+        
+        UserDefaults.standard.set(listOfDisabledSymbologies, forKey: symbologiesKey)
+        UserDefaults.standard.synchronize()
+        
+        let dataSource = SKTCaptureDataSource()
+        dataSource.id = symbologyId
+        dataSource.status = .disabled
+        device.setDataSourceInfo(dataSource) { (result) in
+            if result != SKTResult.E_NOERROR {
+                print("Error disabling symbology with id: \(symbologyId)")
+            }
+            print("result: \(result)")
+        }
+        
+    }
+    
+    public func restoreDefaultSettings() {
+        
+        guard let device = CaptureHelper.sharedInstance.getDevices().first else { return }
+        print("device friendly name: \(device.deviceInfo.name)")
+        
+        if let listOfDisabledSymbologies = disabledSymbologies {
+            
+            for i in 0..<listOfDisabledSymbologies.count {
+                
+                let rawValue = listOfDisabledSymbologies[i]
+                let dataSource = SKTCaptureDataSource()
+                guard let sourceId = SKTCaptureDataSourceID(rawValue: rawValue) else { continue }
+                dataSource.id = sourceId
+                dataSource.status = .enabled
+                
+                device.setDataSourceInfo(dataSource) { (result) in
+                    if result != SKTResult.E_NOERROR {
+                        print("Error re enabling dataSource: \(dataSource)")
+                    }
+                    print("restore result: \(result) --- for dataSource: \(dataSource)")
+                }
+                
+            }
+        }
+        
+        let dictionary = UserDefaults.standard.dictionaryRepresentation()
+        dictionary.keys.forEach { (key) in
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        UserDefaults.standard.synchronize()
+    }
+}

--- a/Over21/Settings.swift
+++ b/Over21/Settings.swift
@@ -20,6 +20,9 @@ class Settings: NSObject {
     }
     
     
+    
+    
+    
     public var disabledSymbologies: [Int]? {
         return UserDefaults.standard.array(forKey: symbologiesKey) as? [Int]
     }

--- a/Over21/Settings.swift
+++ b/Over21/Settings.swift
@@ -43,9 +43,8 @@ class Settings: NSObject {
             
             if result != SKTResult.E_NOERROR {
                 print("Error disabling symbology with id: \(symbologyId)")
+                return
             }
-            print("result: \(result)")
-            
             
             guard listOfDisabledSymbologies.contains(symbologyId.rawValue) == false else {
                 // Keep from adding the same disabled symbologies more than once

--- a/Over21/Settings.swift
+++ b/Over21/Settings.swift
@@ -19,8 +19,6 @@ class Settings: NSObject {
         super.init()
     }
     
-    private var device = CaptureHelper.sharedInstance.getDevices().first
-    
     
     public var disabledSymbologies: [Int]? {
         return UserDefaults.standard.array(forKey: symbologiesKey) as? [Int]

--- a/Over21/Settings.swift
+++ b/Over21/Settings.swift
@@ -35,24 +35,27 @@ class Settings: NSObject {
             listOfDisabledSymbologies = list
         }
         
-        guard listOfDisabledSymbologies.contains(symbologyId.rawValue) == false else {
-            // Keep from adding the same disabled symbologies more than once
-            return
-        }
-        
-        listOfDisabledSymbologies.append(symbologyId.rawValue)
-        
-        UserDefaults.standard.set(listOfDisabledSymbologies, forKey: symbologiesKey)
-        UserDefaults.standard.synchronize()
-        
         let dataSource = SKTCaptureDataSource()
         dataSource.id = symbologyId
         dataSource.status = .disabled
-        device.setDataSourceInfo(dataSource) { (result) in
+        device.setDataSourceInfo(dataSource) { [weak self] (result) in
+            guard let strongSelf = self else { return }
+            
             if result != SKTResult.E_NOERROR {
                 print("Error disabling symbology with id: \(symbologyId)")
             }
             print("result: \(result)")
+            
+            
+            guard listOfDisabledSymbologies.contains(symbologyId.rawValue) == false else {
+                // Keep from adding the same disabled symbologies more than once
+                return
+            }
+            
+            listOfDisabledSymbologies.append(symbologyId.rawValue)
+            
+            UserDefaults.standard.set(listOfDisabledSymbologies, forKey: strongSelf.symbologiesKey)
+            UserDefaults.standard.synchronize()
         }
         
     }

--- a/Over21/controllers/ContainerViewController.swift
+++ b/Over21/controllers/ContainerViewController.swift
@@ -1,0 +1,128 @@
+//
+//  ContainerViewController.swift
+//  Over21
+//
+//  Created by Chrishon Wyllie on 11/13/18.
+//  Copyright © 2018 Socket Mobile. All rights reserved.
+//
+
+import UIKit
+
+class ContainerViewController: UIPageViewController {
+    
+    private var controllers: [UIViewController] = []
+    private var mainController: ViewController!
+    private var settingsController: SettingsController!
+    private var startIndex = 0
+    
+    private var pageControl: UIPageControl = {
+        let p = UIPageControl()
+        p.translatesAutoresizingMaskIntoConstraints = false
+        p.numberOfPages = 2
+        p.hidesForSinglePage = true
+        p.currentPageIndicatorTintColor = entryMAYBEAllowedColor
+        p.pageIndicatorTintColor = UIColor.lightGray
+        return p
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupUIElements()
+    }
+    
+    private func setupUIElements() {
+        
+        view.backgroundColor = .red
+        view.addSubview(pageControl)
+        
+        pageControl.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        pageControl.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: 0).isActive = true
+        pageControl.isUserInteractionEnabled = true
+        pageControl.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toggleCurrentViewController)))
+        
+        mainController = ViewController()
+        mainController.delegate = self
+        settingsController = SettingsController()
+        
+        controllers = [mainController, settingsController]
+        
+        setViewControllers([controllers[startIndex]], direction: .forward, animated: false, completion: nil)
+        
+        delegate = self
+        dataSource = self
+    }
+
+    @objc private func toggleCurrentViewController() {
+        guard let currentController = viewControllers?.first else { return }
+        let destinationController = currentController == mainController ? settingsController : mainController
+        let direction: UIPageViewController.NavigationDirection = currentController == mainController ? .forward : .reverse
+        
+        pageControl.currentPage = destinationController == mainController ? 0 : 1
+        
+        setViewControllers([destinationController!], direction: direction, animated: true, completion: nil)
+    }
+    
+}
+
+extension ContainerViewController: UIPageViewControllerDelegate {
+    
+    func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
+        
+        guard let controller = previousViewControllers.first else { return }
+        pageControl.currentPage = controller == mainController ? 1 : 0
+    }
+    
+}
+
+extension ContainerViewController: UIPageViewControllerDataSource {
+    
+    private enum ControllerPage {
+        case before
+        case after
+    }
+    
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
+        return getViewController(from: viewController, page: .before)
+    }
+    
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
+        return getViewController(from: viewController, page: .after)
+    }
+    
+    private func getViewController(from controller: UIViewController, page: ControllerPage) -> UIViewController? {
+        var currentIndex: Int = controllers.index(of: controller)!
+        
+        if page == .before {
+            if currentIndex != 0 {
+                currentIndex -= 1
+                currentIndex = currentIndex % controllers.count
+                return controllers[currentIndex]
+            }
+            return nil
+        } else {
+            if currentIndex != controllers.count - 1 {
+                currentIndex += 1
+                currentIndex = currentIndex % controllers.count
+                return controllers[currentIndex]
+            }
+            return nil
+        }
+        
+    }
+}
+
+
+extension ContainerViewController: ContainerDelegate {
+    
+    func didScan() {
+        // If the user scans a barcode but has the settings controller open,
+        // switch back to the main controller
+        guard let currentController = viewControllers?.first else { return }
+        if currentController == mainController {
+            return
+        }
+        toggleCurrentViewController()
+    }
+    
+}

--- a/Over21/controllers/ContainerViewController.swift
+++ b/Over21/controllers/ContainerViewController.swift
@@ -33,7 +33,7 @@ class ContainerViewController: UIPageViewController {
     
     private func setupUIElements() {
         
-        view.backgroundColor = .red
+        view.backgroundColor = .white
         view.addSubview(pageControl)
         
         pageControl.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true

--- a/Over21/controllers/SettingsController.swift
+++ b/Over21/controllers/SettingsController.swift
@@ -1,0 +1,99 @@
+//
+//  SettingsController.swift
+//  Over21
+//
+//  Created by Chrishon Wyllie on 11/13/18.
+//  Copyright © 2018 Socket Mobile. All rights reserved.
+//
+
+import UIKit
+
+class SettingsController: UIViewController {
+    
+    // MARK: - Variables
+    
+    private let reuseIdentifier: String = "SettingsCell"
+    
+    
+    
+    
+    
+    // MARK: - UI Elements
+    
+    private lazy var tableView: UITableView = {
+        let tbv = UITableView()
+        tbv.translatesAutoresizingMaskIntoConstraints = false
+        tbv.backgroundColor = .clear
+        tbv.allowsSelection = false
+        tbv.isScrollEnabled = false
+        tbv.separatorStyle = .none
+        tbv.delegate = self
+        tbv.dataSource = self
+        return tbv
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupUIElements()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        // Reload in the case that the disabled symbologies have changed
+        tableView.reloadData()
+    }
+    
+    private func setupUIElements() {
+        view.backgroundColor = .white
+
+        view.addSubview(tableView)
+        
+        tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+        tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
+        
+        tableView.register(SettingsCell.self, forCellReuseIdentifier: reuseIdentifier)
+
+    }
+
+}
+
+
+extension SettingsController: UITableViewDelegate, UITableViewDataSource {
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell: SettingsCell?
+        
+        cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath) as? SettingsCell
+        
+        cell?.toggleButton.isEnabled = (Settings.shared.disabledSymbologies?.count ?? 0) > 0
+        
+        cell?.delegate = self
+        
+        return cell!
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 160.0
+    }
+    
+}
+
+extension SettingsController: SettingsCellDelegate {
+    func toggleButtonPressed() {
+        print("restore all symbologies")
+        Settings.shared.restoreDefaultSettings()
+        tableView.reloadData()
+        
+    }
+}

--- a/Over21/controllers/ViewController.swift
+++ b/Over21/controllers/ViewController.swift
@@ -9,6 +9,10 @@
 import UIKit
 import SKTCapture
 
+protocol ContainerDelegate: class {
+    func didScan()
+}
+
 class ViewController: UIViewController {
     
     // MARK: - Variables
@@ -25,6 +29,8 @@ class ViewController: UIViewController {
     // If setting this notification fails, this Boolean will save the state
     private var buttonReleaseIsSupported: Bool = true
     private var animationTimer: Timer?
+    
+    public weak var delegate: ContainerDelegate?
     
     
     
@@ -92,6 +98,7 @@ class ViewController: UIViewController {
     }
     
     private func setupUIElements() {
+        view.backgroundColor = .white
         view.addSubview(ageIndicatorView)
         view.addSubview(ageLimitSelectionView)
         
@@ -103,7 +110,7 @@ class ViewController: UIViewController {
         ageIndicatorView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
         ageIndicatorView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
         
-        appVersionLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16).isActive = true
+        appVersionLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -48).isActive = true
         appVersionLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         appVersionLabel.heightAnchor.constraint(equalToConstant: 30).isActive = true
         appVersionLabel.text = getAppVersion()
@@ -263,8 +270,11 @@ extension ViewController: CaptureHelperDeviceDecodedDataDelegate {
     func didReceiveDecodedData(_ decodedData: SKTCaptureDecodedData?, fromDevice device: CaptureHelperDevice, withResult result: SKTResult) {
         if result == SKTCaptureErrors.E_NOERROR {
             
+            delegate?.didScan()
+            
             if let dataSourceID = decodedData?.dataSourceID {
                 if dataSourceID != SKTCaptureDataSourceID.symbologyPdf417 {
+                    Settings.shared.disableDataSource(withId: dataSourceID, forDevice: device)
                     notificationsView.setMessage(to: "Scanned the wrong barcode. Try again")
                     notificationsView.animate(shouldShow: true)
                     return

--- a/Over21/views/SettingsCell.swift
+++ b/Over21/views/SettingsCell.swift
@@ -1,0 +1,73 @@
+//
+//  SettingsCell.swift
+//  Over21
+//
+//  Created by Chrishon Wyllie on 11/13/18.
+//  Copyright © 2018 Socket Mobile. All rights reserved.
+//
+
+import UIKit
+
+protocol SettingsCellDelegate: class {
+    func toggleButtonPressed()
+}
+
+class SettingsCell: UITableViewCell {
+    
+    // MARK: - Variables
+    
+    public weak var delegate: SettingsCellDelegate?
+    
+    
+    
+    
+    // MARK: - UI Elements
+    
+    public lazy var toggleButton: UIButton = {
+        let btn = UIButton(type: .system)
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        btn.setTitle("Restore Scanner Defaults", for: .normal)
+        btn.setTitleColor(.red, for: .normal)
+        btn.setTitleColor(.darkGray, for: UIControl.State.disabled)
+        btn.titleLabel?.font = UIFont.systemFont(ofSize: 20)
+        btn.layer.cornerRadius = 10
+        btn.layer.borderColor = UIColor.groupTableViewBackground.cgColor
+        btn.layer.borderWidth = 1
+        btn.addTarget(self, action: #selector(toggle), for: .touchUpInside)
+        return btn
+    }()
+    
+    
+    
+    
+    
+    // MARK: - Initializer
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUIElements()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    
+    
+    
+    // MARK: - Functions
+    
+    private func setupUIElements() {
+        addSubview(toggleButton)
+        
+        toggleButton.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        toggleButton.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+        toggleButton.heightAnchor.constraint(equalToConstant: 60.0).isActive = true
+        toggleButton.widthAnchor.constraint(equalToConstant: 250.0).isActive = true
+    }
+    
+    @objc private func toggle() {
+        delegate?.toggleButtonPressed()
+    }
+}


### PR DESCRIPTION
closes #20 

When scanning a barcode whose data source is not PDF417, a message will appear on screen that says "Scanned the wrong barcode. Try again" (just like before). The symbology is then automatically disabled.

Added a Settings page.

Added a "Restore Scanner Defaults" button to the Settings page that will re-enable all the previously disabled symbologies (only the ones that Over21 has disabled)

The. purpose of the ContainerViewController is to manage the main ViewController (where the device arrival, decodedData, etc. is handled) and the SettingsController (to restore the default scanner configuration) while keeping the UI clean.
