### PR TITLE
Reversed the function call order when scanning begins

### DIFF
--- a/Over21/ViewController.swift
+++ b/Over21/ViewController.swift
@@ -234,8 +234,8 @@ extension ViewController: CaptureHelperDeviceButtonsDelegate {
         } else {
             if buttonsState == .middle {
                 notificationsView.reset()
-                ageIndicatorView.updateUserInterface(isScanning: true)
                 ageIndicatorView.reset()
+                ageIndicatorView.updateUserInterface(isScanning: true)
             } else {
                 ageIndicatorView.updateUserInterface(isScanning: false)
             }


### PR DESCRIPTION
closes #25

The reset function was causing the animation to stop after it was previously told to begin. Reversing the order (reset called before updateUserInterface) fixes this issue.