### PR TITLE
Toggle the restore config button when a device connects or disconnects

### DIFF
--- a/Over21/controllers/ContainerViewController.swift
+++ b/Over21/controllers/ContainerViewController.swift
@@ -125,4 +125,8 @@ extension ContainerViewController: ContainerDelegate {
         toggleCurrentViewController()
     }
     
+    func deviceConnectionStatusChanged(isConnected: Bool) {
+        settingsController.tableView.reloadData()
+    }
+    
 }

--- a/Over21/controllers/SettingsController.swift
+++ b/Over21/controllers/SettingsController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SKTCapture
 
 class SettingsController: UIViewController {
     
@@ -20,7 +21,7 @@ class SettingsController: UIViewController {
     
     // MARK: - UI Elements
     
-    private lazy var tableView: UITableView = {
+    public lazy var tableView: UITableView = {
         let tbv = UITableView()
         tbv.translatesAutoresizingMaskIntoConstraints = false
         tbv.backgroundColor = .clear
@@ -76,7 +77,10 @@ extension SettingsController: UITableViewDelegate, UITableViewDataSource {
         
         cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath) as? SettingsCell
         
-        cell?.toggleButton.isEnabled = (Settings.shared.disabledSymbologies?.count ?? 0) > 0
+        let numberOfDisabledSymbologies = (Settings.shared.disabledSymbologies?.count ?? 0)
+        let numberOfConnectedDevices = CaptureHelper.sharedInstance.getDevices().count
+        
+        cell?.toggleButton.isEnabled = (numberOfDisabledSymbologies > 0 && numberOfConnectedDevices > 0)
         
         cell?.delegate = self
         

--- a/Over21/controllers/ViewController.swift
+++ b/Over21/controllers/ViewController.swift
@@ -11,6 +11,7 @@ import SKTCapture
 
 protocol ContainerDelegate: class {
     func didScan()
+    func deviceConnectionStatusChanged(isConnected: Bool)
 }
 
 class ViewController: UIViewController {
@@ -144,6 +145,9 @@ extension ViewController: CaptureHelperDevicePresenceDelegate {
     
     func didNotifyArrivalForDevice(_ device: CaptureHelperDevice, withResult result: SKTResult) {
         print("scanner arrived")
+        
+        delegate?.deviceConnectionStatusChanged(isConnected: true)
+        
         ageIndicatorView.updateScannerConnection(isConnected: true)
         
         device.dispatchQueue = DispatchQueue.main
@@ -163,6 +167,7 @@ extension ViewController: CaptureHelperDevicePresenceDelegate {
     
     func didNotifyRemovalForDevice(_ device: CaptureHelperDevice, withResult result: SKTResult) {
         print("scanner removed")
+        delegate?.deviceConnectionStatusChanged(isConnected: false)
         ageIndicatorView.updateScannerConnection(isConnected: false)
         ageIndicatorView.reset()
         notificationsView.reset()


### PR DESCRIPTION
closes #28 

When a device connects or disconnects, a delegate is notified to reload the SettingsController.

This causes the Restore Config Button to check if there are any connected devices and disabled symbologies (Capture Helper devices.count > 0 and number of disabled symbologies > 0).

If either of these counts are 0, the button is disabled. 